### PR TITLE
Fix sampler selection in api.py

### DIFF
--- a/api.py
+++ b/api.py
@@ -189,7 +189,7 @@ def processAPI():
     oinfo = []
     smp_index=0
     for i in range(0,len(samplers_k_diffusion)):
-        if samplers_k_diffusion[i][0]=="LMS": smp_index=i    
+        if samplers_k_diffusion[i][0]==data['sampler']: smp_index=i    
     if data['mode'] == 'txt2img':
         oimages, oinfo, ohtml = txt2img(data['prompt'],'',data['steps'],smp_index,data['use_gfpgan'],data['batch_count'],1,data['cfg_scale'],data['seed'],data['height'],data['width'],0)
 


### PR DESCRIPTION
It was using the 'LMS' sampler even when other samplers were selected from Krita plugin.